### PR TITLE
feat: Can now inject services with API Key and URL as strings

### DIFF
--- a/src/DiscosWebSdk/DiscosWebSdk/DependencyInjection/DependencyInjectionExtensions.cs
+++ b/src/DiscosWebSdk/DiscosWebSdk/DependencyInjection/DependencyInjectionExtensions.cs
@@ -7,6 +7,7 @@ using DiscosWebSdk.Interfaces.Queries;
 using DiscosWebSdk.Options;
 using DiscosWebSdk.Queries.Builders;
 using DiscosWebSdk.Services.BulkFetching;
+using JetBrains.Annotations;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Polly;
@@ -17,7 +18,12 @@ public static class DependencyInjectionExtensions
 {
 	private static readonly List<TimeSpan> DefaultRetrySpans = new[] {1, 2, 5, 10, 30, 60, 60, 60}.Select(i => TimeSpan.FromSeconds(i)).ToList();
 	
-	public static void AddDiscosServices(this IServiceCollection services, IConfiguration configuration, bool usePolly = false, IEnumerable<TimeSpan>? retrySpans = null)
+	public static void AddDiscosServices(this IServiceCollection services, IConfiguration configuration, bool usePolly = false, IEnumerable<TimeSpan>? retrySpans = null) => services.RegisterEverything(configuration, usePolly, retrySpans);
+	
+	public static void AddDiscosServices(this IServiceCollection services, string apiUrl, string apiKey, bool usePolly = false, IEnumerable<TimeSpan>? retrySpans = null) => services.RegisterEverything(BuildConfiguration(apiUrl, apiKey), usePolly, retrySpans);
+
+	[UsedImplicitly]
+	private static IServiceCollection RegisterEverything(this IServiceCollection services, IConfiguration configuration, bool usePolly = false, IEnumerable<TimeSpan>? retrySpans = null)
 	{
 		IConfigurationSection configSection = configuration.GetSection(nameof(DiscosOptions));
 		DiscosOptions         opt           = configSection.Get<DiscosOptions>();
@@ -51,8 +57,23 @@ public static class DependencyInjectionExtensions
 																	c.DefaultRequestHeaders.Authorization = new("bearer", opt.DiscosApiKey);
 																});
 		}
+		return services;
+	}
 
-		
+	private static IConfiguration BuildConfiguration(string apiUrl, string apiKey)
+	{
+		if (string.IsNullOrWhiteSpace(apiUrl) || string.IsNullOrWhiteSpace(apiKey))
+		{
+			throw new InvalidDiscosConfigurationException("DISCOS API key and URL not set");
+		}
 
+		IConfigurationBuilder builder = new ConfigurationBuilder()
+		   .AddInMemoryCollection(new Dictionary<string, string>
+								  {
+									  { "DiscosOptions:DiscosApiKey", apiUrl},
+									  { "DiscosOptions:DiscosApiUrl", apiKey}
+								  });
+
+		return builder.Build();
 	}
 }

--- a/src/DiscosWebSdk/DiscosWebSdk/DiscosWebSdk.csproj
+++ b/src/DiscosWebSdk/DiscosWebSdk/DiscosWebSdk.csproj
@@ -27,25 +27,26 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="AutoFixture" Version="4.17.0"/>
-        <PackageReference Include="EnumExtensions.System.Text.Json" Version="1.1.0"/>
-        <PackageReference Include="Hughesjs.Hypermedia.Core" Version="3.1.2"/>
-        <PackageReference Include="Hughesjs.Hypermedia.JsonApi.Client" Version="3.1.2"/>
-        <PackageReference Include="JetBrains.Annotations" Version="2022.1.0"/>
-        <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0"/>
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0"/>
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0"/>
-        <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0"/>
-        <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="6.0.7"/>
-        <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="6.0.0"/>
-        <PackageReference Include="EnumExtensions.System.Text.Json" Version="1.1.0"/>
-        <PackageReference Include="JetBrains.Annotations" Version="2022.1.0"/>
-        <PackageReference Include="Microsoft.Extensions.Options" Version="6.0.0"/>
+        <PackageReference Include="AutoFixture" Version="4.17.0" />
+        <PackageReference Include="EnumExtensions.System.Text.Json" Version="1.1.0" />
+        <PackageReference Include="Hughesjs.Hypermedia.Core" Version="3.1.2" />
+        <PackageReference Include="Hughesjs.Hypermedia.JsonApi.Client" Version="3.1.2" />
+        <PackageReference Include="JetBrains.Annotations" Version="2022.1.0" />
+        <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.1" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="6.0.7" />
+        <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="6.0.0" />
+        <PackageReference Include="EnumExtensions.System.Text.Json" Version="1.1.0" />
+        <PackageReference Include="JetBrains.Annotations" Version="2022.1.0" />
+        <PackageReference Include="Microsoft.Extensions.Options" Version="6.0.0" />
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Polly.Extensions.Http" Version="3.0.0"/>
+        <PackageReference Include="Polly.Extensions.Http" Version="3.0.0" />
     </ItemGroup>
 
 
@@ -57,7 +58,7 @@
 
     <ItemGroup>
 
-        <Folder Include="Exceptions\DataStructures"/>
+        <Folder Include="Exceptions\DataStructures" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Doesn't entirely break the dependence on IConfiguration (this can be sorted as part of #52) but it's good enough for now.

Fixes #82 